### PR TITLE
Update dependencies.cmake

### DIFF
--- a/src/maps/ktprime/dependencies.cmake
+++ b/src/maps/ktprime/dependencies.cmake
@@ -1,2 +1,1 @@
-# khash requires -fno-strict-aliasing
-target_compile_options(${EXECUTABLE_NAME} PUBLIC -fno-strict-aliasing)
+


### PR DESCRIPTION
no need it again. 
can you add one more hash map emhash7
https://github.com/ktprime/emhash/blob/master/hash_table7.hpp

emhash8 is only fast on iteration/find miss/big key-value.

