### PR TITLE
add some include headers to make compile for some versions of gcc/clang

### DIFF
--- a/src/app/pool.h
+++ b/src/app/pool.h
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <list>
 #include <new>
+#include <memory>
 #include <type_traits>
 #include <utility>
 

--- a/src/benchmarks/RandomFind.cpp
+++ b/src/benchmarks/RandomFind.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <iomanip>
+#include <sstream>
 
 uint64_t randomFindInternal(Bench& bench, size_t numRandom, uint64_t bitMask, size_t numInserts, size_t numFindsPerInsert) {
     size_t constexpr NumTotal = 4;

--- a/src/benchmarks/RandomFindString.cpp
+++ b/src/benchmarks/RandomFindString.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <iomanip>
+#include <sstream>
 
 uint64_t randomFindInternalString(Bench& bench, size_t numRandom, size_t const length, size_t numInserts, size_t numFindsPerInsert) {
     size_t constexpr NumTotal = 4;


### PR DESCRIPTION
The current codes will fail to compile due to the lack of some headers, including <sstream> and <memory>.