### PR TITLE
add no-seed version of fph-table

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 	path = external/jiwan__dense_hash_map
 	url = https://github.com/Jiwan/dense_hash_map.git
 	branch = master
+[submodule "external/fph__dynamic_fph_map"]
+	path = external/fph__noseed_fph_map
+	url = https://github.com/renzibei/fph-table.git

--- a/src/maps/dynamic_fph_map/Map.h
+++ b/src/maps/dynamic_fph_map/Map.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "Hash.h"
+#include "fph__noseed_fph_map/include/fph/dynamic_fph_table.h"
+
+static const char* MapName = "fph::DynamicFphMap";
+
+template <class Key, class Val>
+using Map = fph::DynamicFphMap<Key, Val, Hash<Key>>;


### PR DESCRIPTION
I add the [no-seed version of fph-table](https://github.com/renzibei/fph-table/tree/noseed) to this benchmark.
fph-table is a "perfect hash table". It's ultra fast for lookup but slow for insert operations.