### PR TITLE
Cleanup build by making folly build optional and adding aggregate map and hash builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
-# folly 
+# folly
 # install dependencies, see https://github.com/facebook/folly
 # sudo apt-get install \
 #   g++ \
@@ -73,9 +73,14 @@ find_package(Threads REQUIRED)
 # make sure we get SSE and crc support!
 # see https://github.com/facebook/folly/blob/master/folly/container/detail/F14Table.cpp#L26
 
-# NOPE, folly just doesn't work.
-#add_subdirectory("external/facebook__folly")
-#add_subdirectory("external/electronicarts__EASTL")
+# folly is disabled by default
+option(ENABLE_FOLLY "dont't build facebook folly" FALSE)
+if (ENABLE_FOLLY)
+    add_subdirectory("external/facebook__folly")
+else ()
+    list(FILTER INC_MAPS EXCLUDE REGEX "maps[\\/]folly_")
+endif ()
+
 
 # build stuff #####################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ find_package(Threads REQUIRED)
 # see https://github.com/facebook/folly/blob/master/folly/container/detail/F14Table.cpp#L26
 
 # folly is disabled by default
-option(ENABLE_FOLLY "dont't build facebook folly" FALSE)
+option(ENABLE_FOLLY "enable facebook folly build" FALSE)
 if (ENABLE_FOLLY)
     add_subdirectory("external/facebook__folly")
 else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,15 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 endif ()
 
 # create targets for all map - hash pairs
+
+foreach(HASH_DIR ${INC_HASHES})
+    get_filename_component(HASH_NAME ${HASH_DIR} NAME_WE)
+    add_custom_target("${HASH_NAME}_all") # aggregate of map targets
+endforeach(HASH_DIR ${INC_HASHES})
+
 foreach(MAP_DIR ${INC_MAPS})
     get_filename_component(MAP_NAME ${MAP_DIR} NAME_WE)
+    add_custom_target("${MAP_NAME}_all") # aggregate of hash targets
     foreach(HASH_DIR ${INC_HASHES})
         # executable name: mapname_hashname
         get_filename_component(HASH_NAME ${HASH_DIR} NAME_WE)
@@ -111,7 +118,7 @@ foreach(MAP_DIR ${INC_MAPS})
 
         add_executable(${EXECUTABLE_NAME} ${SRC_APP} ${SRC_BENCHMARKS} ${SRC_MAP_DIR} ${SRC_HASH_DIR})
         target_include_directories(${EXECUTABLE_NAME} PRIVATE "src/app" "external" ${MAP_DIR} ${HASH_DIR} ${FOLLY_DIR})
-        
+
         if (EXISTS "${MAP_DIR}/dependencies.cmake")
             include("${MAP_DIR}/dependencies.cmake")
         endif ()
@@ -120,5 +127,7 @@ foreach(MAP_DIR ${INC_MAPS})
             include("${HASH_DIR}/dependencies.cmake")
         endif ()
 
+        add_dependencies("${HASH_NAME}_all" ${EXECUTABLE_NAME})
+        add_dependencies("${MAP_NAME}_all" ${EXECUTABLE_NAME})
     endforeach(HASH_DIR ${INC_HASHES})
 endforeach(MAP_DIR ${INC_MAPS})


### PR DESCRIPTION
Makes folly build optional (can be enabled with `-DENABLE_FOLLY=TRUE`) and adds aggregate `<HASH>_all` and `<MAP>_all` targets.

If you just want to evaluate a hash map against other hash maps, then building all hashes often isn't necessary, so having an aggregate target is quite helpful. Similarly, evaluating a hash implementation doesn't require you to build all hash tables.
