### PR TITLE
CreateInsert & ClearInsert benchmarks

### DIFF
--- a/src/benchmarks/Insert.cpp
+++ b/src/benchmarks/Insert.cpp
@@ -42,3 +42,70 @@ BENCHMARK(InsertHugeInt) {
     }
     bench.endMeasure(0, 0);
 }
+
+std::array<size_t, 7> counts = {
+	200, 2000, 2000, 20000, 200000, 2000000, 20000000
+};
+
+std::array<size_t, 7> results = {
+	20000000, 19999999, 19999998, 19999957, 19999529, 19995213, 19953523
+};
+
+BENCHMARK(CreateInsert) {
+    sfc64 rng(213);
+    for (size_t i = 0; i < counts.size(); ++i) {
+        size_t count = counts[i];
+        size_t repeats = counts.back() / count;
+        size_t res = 0;
+
+        bench.beginMeasure(("creating and inserting " + std::to_string(count) +
+                            " ints " + std::to_string(repeats) +
+                            " times").c_str());
+
+        for (size_t j = 0; j < repeats; ++j) {
+
+            using M = Map<int, int>;
+#ifdef USE_POOL_ALLOCATOR
+            Resource<int, int> resource;
+            M map{0, M::hasher{}, M::key_equal{}, &resource};
+#else
+            M map;
+#endif
+
+            for (size_t n = 0; n < count; ++n)
+                map[static_cast<int>(rng())];
+            res += map.size();
+        }
+        bench.endMeasure(results[i], res);
+    }
+}
+
+BENCHMARK(ClearInsert) {
+    sfc64 rng(213);
+    for (size_t i = 0; i < counts.size(); ++i) {
+        size_t count = counts[i];
+        size_t repeats = counts.back() / count;
+        size_t res = 0;
+
+        using M = Map<int, int>;
+#ifdef USE_POOL_ALLOCATOR
+        Resource<int, int> resource;
+        M map{0, M::hasher{}, M::key_equal{}, &resource};
+#else
+        M map;
+#endif
+
+        bench.beginMeasure(("inserting and clearing " + std::to_string(count) +
+                            " ints " + std::to_string(repeats) +
+                            " times").c_str());
+
+        for (size_t j = 0; j < repeats; ++j) {
+            for (size_t n = 0; n < count; ++n)
+                map[static_cast<int>(rng())];
+            res += map.size();
+            map.clear();
+        }
+        bench.endMeasure(results[i], res);
+    }
+}
+


### PR DESCRIPTION
The benchmarks are kind of similar to `InsertHugeInt`, but stress test different sizes, some maps seem to really struggle after certain sizes:

![ClearInsert](https://user-images.githubusercontent.com/69110542/224576822-437fe830-30b3-4531-98e1-9c2ca88510b7.png)

![CreateInsert](https://user-images.githubusercontent.com/69110542/224576823-94b28b09-174b-4aef-a8fa-c65c0e748120.png)

(The above was just a quick average of two benchmark with the timeout set to 100s)

---

This was the last benchmark I had lying around on my system, but I think an erase-if benchmark is still missing.

I tried implementing one today, but I don't really see a good way of doing it, as creating the map is always way more expensive than the erase-if.
Also, abseil has non-standard iterators, and I'm not sure if all the other maps confirm to the standard implementation.
